### PR TITLE
fix: build rootfs without a journal

### DIFF
--- a/meta-rugix-rpi-tryboot/wic/sdimage-rugix-rpi-tryboot.wks.in
+++ b/meta-rugix-rpi-tryboot/wic/sdimage-rugix-rpi-tryboot.wks.in
@@ -1,6 +1,6 @@
 part --source rpi-tryboot --ondisk mmcblk0 --align 4096 --fixed-size 64M --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B
 part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --align 4096 --fixed-size 128M --part-type EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
 part --source empty --ondisk mmcblk0 --fstype=vfat --align 4096 --fixed-size 128M --part-type EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --align 4096 --part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --align 4096 --part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4 --mkfs-extraopts "-O ^has_journal"
 
 bootloader --ptable gpt


### PR DESCRIPTION
Ensure that the root filesystems used in the wks and the rugixb file doesn't have journaling enabled as this prevents the delta updates from functioning.

With this change, a successful static delta update was done in the thin-edge.io integration, https://github.com/thin-edge/meta-tedge/pull/276